### PR TITLE
Added MACRO for Kernel >= 4.8.0

### DIFF
--- a/parasite_loader/main.c
+++ b/parasite_loader/main.c
@@ -2,10 +2,20 @@
 #include <linux/module.h>
 #include <linux/uaccess.h>
 #include <linux/kallsyms.h>
+#include <linux/version.h>
 
+
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4,8,0)
 #ifndef user_addr_max
-# define user_addr_max()	(current_thread_info()->addr_limit.seg)
+# define user_addr_max()      (current_thread_info()->addr_limit.seg)
 #endif
+#else
+#ifndef user_addr_max
+# define user_addr_max() (current->thread.addr_limit.seg)
+#endif
+#endif
+
+
 
 #include "encrypt/encrypt.h"
 

--- a/parasite_loader/main.c
+++ b/parasite_loader/main.c
@@ -4,15 +4,12 @@
 #include <linux/kallsyms.h>
 #include <linux/version.h>
 
-
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(4,8,0)
 #ifndef user_addr_max
-# define user_addr_max()      (current_thread_info()->addr_limit.seg)
-#endif
-#else
-#ifndef user_addr_max
-# define user_addr_max() (current->thread.addr_limit.seg)
-#endif
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
+		# define user_addr_max()      (current_thread_info()->addr_limit.seg)
+	#else
+		# define user_addr_max() (current->thread.addr_limit.seg)
+	#endif
 #endif
 
 


### PR DESCRIPTION
The memory limit location was moved since Kernel 4.8.0 [ https://elixir.bootlin.com/linux/v4.8/source/arch/x86/include/asm/uaccess.h#L37 ]
